### PR TITLE
Adjust theme contrast for readability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
         <Skills />
         <Contact />
       </main>
-      <footer className="border-t border-white/5 bg-charcoal/70 py-8 text-center text-sm text-slate/70">
+      <footer className="border-t border-white/5 bg-charcoal/70 py-8 text-center text-sm text-slate/80">
         <p>
           Construído por <strong className="text-neon">Deyvid Gondim</strong> · Desenvolvedor Fullstack · {new Date().getFullYear()}
         </p>

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -31,7 +31,7 @@ export function About() {
         <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
           <div className="max-w-2xl">
             <h2 className="section-title text-white">Resumo Profissional</h2>
-            <p className="mt-4 text-base text-slate/80 md:text-lg">
+            <p className="mt-4 text-base text-slate/90 md:text-lg">
               Desenvolvedor fullstack com experiência prática em todo o ciclo de produtos digitais. Lidero arquiteturas distribuídas, construo interfaces modernas e orquestro deploys seguros em ambientes conteinerizados. Atuo tanto em squads multidisciplinares quanto liderando iniciativas de ponta a ponta.
             </p>
           </div>
@@ -39,7 +39,7 @@ export function About() {
             {SUMMARY_STATS.map(stat => (
               <div key={stat.label}>
                 <span className="text-xl font-semibold text-neon">{stat.value}</span>
-                <p className="text-sm text-slate/80">{stat.label}</p>
+                <p className="text-sm text-slate/90">{stat.label}</p>
               </div>
             ))}
           </div>
@@ -51,7 +51,7 @@ export function About() {
           <Reveal key={focus.title} delay={150 * index}>
             <article className="glass-panel h-full rounded-2xl p-6">
               <h3 className="text-lg font-semibold text-white">{focus.title}</h3>
-              <p className="mt-3 text-sm text-slate/80">{focus.description}</p>
+              <p className="mt-3 text-sm text-slate/90">{focus.description}</p>
             </article>
           </Reveal>
         ))}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -8,7 +8,7 @@ export function Contact() {
         <div className="glass-panel rounded-3xl p-10 text-center">
           <span className="text-sm font-mono uppercase tracking-[0.3em] text-neon/70">Próximo passo</span>
           <h2 className="mt-4 text-3xl font-semibold text-white md:text-4xl">Vamos acelerar seu próximo produto?</h2>
-          <p className="mx-auto mt-4 max-w-3xl text-base text-slate/80 md:text-lg">
+          <p className="mx-auto mt-4 max-w-3xl text-base text-slate/90 md:text-lg">
             Estou pronto para apoiar desde a concepção da arquitetura até a implementação de features críticas. Entre em contato para construirmos soluções completas com qualidade, segurança e ritmo de escala.
           </p>
 

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -78,12 +78,12 @@ export function Experience() {
                   {experience.role}
                   <span className="ml-2 text-base font-normal text-neon">@ {experience.company}</span>
                 </h3>
-                <span className="text-sm font-mono uppercase tracking-wide text-slate/70">{experience.period}</span>
+                <span className="text-sm font-mono uppercase tracking-wide text-slate/80">{experience.period}</span>
               </div>
 
-              <p className="mt-4 text-sm text-slate/80 md:text-base">{experience.summary}</p>
+              <p className="mt-4 text-sm text-slate/90 md:text-base">{experience.summary}</p>
 
-              <ul className="mt-4 space-y-2 text-sm text-slate/70">
+              <ul className="mt-4 space-y-2 text-sm text-slate/80">
                 {experience.achievements.map(item => (
                   <li key={item} className="flex items-start gap-2">
                     <span className="mt-1 h-1.5 w-1.5 rounded-full bg-neon" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,9 +34,9 @@ export function Header() {
           <span className="font-serif text-xl">Deyvid Gondim</span>
         </a>
 
-        <nav className="hidden md:flex items-center gap-8 text-sm font-medium text-slate/80">
+        <nav className="hidden md:flex items-center gap-8 text-sm font-medium text-slate/90">
           {NAV_ITEMS.map(item => (
-            <a key={item.href} href={item.href} className="link text-slate/80 hover:text-white">
+            <a key={item.href} href={item.href} className="link text-slate/90 hover:text-white">
               {item.label}
             </a>
           ))}

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -37,7 +37,7 @@ export function Main() {
         </Reveal>
 
         <Reveal delay={200}>
-          <p className="max-w-3xl text-lg text-slate/80 md:text-xl">
+          <p className="max-w-3xl text-lg text-slate/90 md:text-xl">
             Eu ajudo empresas a lançarem e escalarem produtos. Lidero arquiteturas modernas, crio interfaces de alta performance e integro serviços confiáveis em ambientes conteinerizados.
           </p>
         </Reveal>
@@ -67,7 +67,7 @@ export function Main() {
             <Reveal key={highlight.label} delay={400 + index * 120}>
               <div className="glass-panel flex h-full flex-col gap-3 rounded-2xl p-6">
                 <h3 className="text-lg font-semibold text-white">{highlight.label}</h3>
-                <p className="text-sm text-slate/80">{highlight.description}</p>
+                <p className="text-sm text-slate/90">{highlight.description}</p>
               </div>
             </Reveal>
           ))}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -80,8 +80,8 @@ export function Projects() {
               <div>
                 <span className="text-sm font-mono uppercase tracking-wide text-neon/80">{project.company}</span>
                 <h3 className="mt-2 text-2xl font-semibold text-white">{project.title}</h3>
-                <p className="mt-3 text-sm text-slate/80">{project.description}</p>
-                <ul className="mt-4 space-y-2 text-sm text-slate/70">
+                <p className="mt-3 text-sm text-slate/90">{project.description}</p>
+                <ul className="mt-4 space-y-2 text-sm text-slate/80">
                   {project.achievements.map(item => (
                     <li key={item} className="flex items-start gap-2">
                       <span className="mt-1 h-1.5 w-1.5 rounded-full bg-neon" />

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -36,7 +36,7 @@ export function Skills() {
           <Reveal key={group.title} delay={index * 120}>
             <div className="glass-panel h-full rounded-2xl p-6">
               <h3 className="text-lg font-semibold text-white">{group.title}</h3>
-              <ul className="mt-4 flex flex-wrap gap-3 text-sm text-slate/80">
+              <ul className="mt-4 flex flex-wrap gap-3 text-sm text-slate/90">
                 {group.items.map(item => (
                   <li key={item} className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-wide text-neon/80">
                     {item}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,10 +12,10 @@ html {
 
 body {
   margin: 0;
-  background: radial-gradient(circle at 10% 20%, rgba(31, 157, 109, 0.12) 0%, transparent 55%),
-              radial-gradient(circle at 90% 10%, rgba(74, 255, 192, 0.08) 0%, transparent 60%),
-              #050c16;
-  color: #f4f8fb;
+  background: radial-gradient(circle at 10% 20%, rgba(31, 157, 109, 0.18) 0%, transparent 55%),
+              radial-gradient(circle at 90% 10%, rgba(74, 255, 192, 0.12) 0%, transparent 60%),
+              #0d1f33;
+  color: #f6fbff;
   font-family: 'Poppins', sans-serif;
 }
 
@@ -81,9 +81,9 @@ body {
 }
 
 .glass-panel {
-  background: linear-gradient(135deg, rgba(15, 32, 48, 0.82), rgba(15, 32, 48, 0.45));
-  border: 1px solid rgba(74, 255, 192, 0.12);
-  box-shadow: 0 24px 60px -30px rgba(12, 24, 38, 0.85);
+  background: linear-gradient(135deg, rgba(27, 50, 74, 0.85), rgba(27, 50, 74, 0.55));
+  border: 1px solid rgba(74, 255, 192, 0.18);
+  box-shadow: 0 24px 60px -30px rgba(12, 24, 38, 0.6);
   backdrop-filter: blur(18px);
 }
 
@@ -92,5 +92,5 @@ body {
 }
 
 .section-subtitle {
-  @apply text-base md:text-lg text-slate/80 max-w-2xl;
+  @apply text-base md:text-lg text-slate/90 max-w-2xl;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,13 +18,13 @@ export default {
     },
     extend: {
       colors: {
-        night: '#050c16',
-        midnight: '#0a1829',
+        night: '#0d1f33',
+        midnight: '#152c44',
         aurora: '#1f9d6d',
         neon: '#4affc0',
-        charcoal: '#0b1320',
-        slate: '#a0b3c5',
-        smoke: '#1f2733'
+        charcoal: '#1b324a',
+        slate: '#c7d6e5',
+        smoke: '#23354b'
       },
       boxShadow: {
         glow: '0 0 35px rgba(74, 255, 192, 0.2)',


### PR DESCRIPTION
## Summary
- lighten the core dark theme palette to increase contrast against text
- brighten global gradients and glass panel styling for better legibility
- update section typography utilities to use higher-contrast slate tones

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917396aceb08331a46d6e16b8fc9976)