### PR TITLE
Revitalize light theme aesthetics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,16 @@ import { ThemeProvider } from './contexts/ThemeContext';
 
 function AppContent() {
   return (
-    <div className="min-h-screen bg-white dark:bg-night text-slate-900 dark:text-white transition-colors duration-300">
+    <div className="relative min-h-screen overflow-hidden bg-white dark:bg-night text-slate-900 dark:text-white transition-colors duration-300">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute inset-x-0 top-0 h-[620px] bg-light-hero opacity-90 blur-[1px] dark:hidden" />
+        <div className="absolute inset-x-0 top-0 hidden h-[520px] bg-gradient-to-b from-charcoal/40 via-night/80 to-night dark:block" />
+        <div className="absolute -left-36 top-60 hidden h-96 w-96 rounded-full bg-aurora/20 blur-3xl dark:block" />
+        <div className="absolute right-[-10%] top-24 hidden h-80 w-80 rounded-full bg-neon/30 blur-3xl dark:block" />
+        <div className="absolute -right-32 top-40 h-80 w-80 rounded-full bg-[radial-gradient(circle_at_center,_rgba(255,231,243,0.6)_0%,_transparent_65%)] blur-3xl dark:hidden" />
+        <div className="absolute left-10 bottom-10 h-72 w-72 rounded-full bg-[radial-gradient(circle_at_center,_rgba(224,242,255,0.65)_0%,_transparent_65%)] blur-3xl dark:hidden" />
+      </div>
+
       <Header />
       <main className="relative overflow-hidden">
         <Main />
@@ -20,9 +29,9 @@ function AppContent() {
         <Skills />
         <Contact />
       </main>
-      <footer className="border-t border-slate-200 dark:border-white/5 bg-slate-100 dark:bg-charcoal/70 py-8 text-center text-sm text-slate-600 dark:text-slate/80">
+      <footer className="border-t border-slate-200/60 bg-gradient-to-r from-white/90 via-skyglass/70 to-white/90 py-8 text-center text-sm text-slate-600 backdrop-blur-md dark:border-white/5 dark:bg-charcoal/70 dark:text-slate/80">
         <p>
-          Construído por <strong className="text-slate-900 dark:text-neon">Deyvid Gondim</strong> · Desenvolvedor Fullstack · {new Date().getFullYear()}
+          Construído por <strong className="bg-gradient-to-r from-aurora via-emerald-500 to-sunrise bg-clip-text text-transparent dark:text-neon">Deyvid Gondim</strong> · Desenvolvedor Fullstack · {new Date().getFullYear()}
         </p>
       </footer>
       <BackToTopButton />

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -27,6 +27,9 @@ const SUMMARY_STATS = [
 export function About() {
   return (
     <section id="resumo" className="relative mx-auto max-w-[1440px] px-6 py-24">
+      <div className="pointer-events-none absolute inset-x-4 top-10 -z-10 h-[420px] rounded-3xl bg-light-layer opacity-80 blur-2xl dark:hidden" />
+      <div className="pointer-events-none absolute inset-x-12 top-20 -z-10 hidden h-[400px] rounded-3xl bg-gradient-to-r from-charcoal/80 via-midnight/80 to-charcoal/80 blur-3xl dark:block" />
+
       <Reveal>
         <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
           <div className="max-w-3xl">
@@ -35,7 +38,8 @@ export function About() {
               Desenvolvedor fullstack com experiência prática em todo o ciclo de produtos digitais. Lidero arquiteturas distribuídas, construo interfaces modernas e orquestro deploys seguros em ambientes conteinerizados. Atuo tanto em squads multidisciplinares quanto liderando iniciativas de ponta a ponta.
             </p>
           </div>
-          <div className="glass-panel grid gap-4 rounded-2xl p-6 md:w-80">
+          <div className="glass-panel relative grid gap-4 overflow-hidden rounded-2xl p-6 shadow-aurora md:w-80">
+            <span className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-aurora via-emerald-400 to-sunrise dark:from-neon dark:via-emerald-400 dark:to-aurora" />
             {SUMMARY_STATS.map(stat => (
               <div key={stat.label}>
                 <span className="text-xl font-semibold text-aurora dark:text-neon">{stat.value}</span>
@@ -49,7 +53,8 @@ export function About() {
       <div className="mt-12 grid gap-6 md:grid-cols-3">
         {FOCUS_AREAS.map((focus, index) => (
           <Reveal key={focus.title} delay={150 * index}>
-            <article className="glass-panel h-full rounded-2xl p-6">
+            <article className="glass-panel relative h-full overflow-hidden rounded-2xl border border-white/60 bg-white/85 p-6 shadow-aurora backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:shadow-card">
+              <span className="pointer-events-none absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-aurora via-sunrise to-skyglass dark:from-neon dark:via-emerald-400 dark:to-aurora" />
               <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{focus.title}</h3>
               <p className="mt-3 text-sm text-slate-700 dark:text-slate/90">{focus.description}</p>
             </article>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -4,8 +4,11 @@ import { Reveal } from './Reveal';
 export function Contact() {
   return (
     <section id="contato" className="relative mx-auto max-w-[1440px] px-6 py-24">
+      <div className="pointer-events-none absolute inset-x-8 top-12 -z-10 h-[360px] rounded-[32px] bg-light-layer opacity-95 blur-2xl dark:hidden" />
+      <div className="pointer-events-none absolute inset-x-12 top-16 -z-10 hidden h-[360px] rounded-[32px] bg-gradient-to-br from-charcoal/90 via-midnight/80 to-charcoal/90 blur-3xl dark:block" />
       <Reveal>
-        <div className="glass-panel rounded-3xl p-10 text-center">
+        <div className="glass-panel relative overflow-hidden rounded-3xl border border-white/70 bg-white/90 p-10 text-center shadow-aurora backdrop-blur-lg dark:border-white/10 dark:bg-white/5 dark:shadow-card">
+          <span className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-aurora via-emerald-400 to-sunrise dark:from-neon dark:via-emerald-400 dark:to-aurora" />
           <span className="text-sm font-mono uppercase tracking-[0.3em] text-aurora/70 dark:text-neon/70">Próximo passo</span>
           <h2 className="mt-4 text-3xl font-semibold text-slate-900 dark:text-white md:text-4xl">Vamos acelerar seu próximo produto?</h2>
           <p className="mx-auto mt-4 max-w-3xl text-base text-slate-700 dark:text-slate/90 md:text-lg">
@@ -15,7 +18,7 @@ export function Contact() {
           <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
             <a
               href="mailto:deyvidgondim@outlook.com"
-              className="group flex items-center gap-2 rounded-full bg-aurora px-6 py-3 text-base font-semibold text-white dark:text-charcoal transition hover:bg-aurora/90 dark:hover:bg-neon"
+              className="group flex items-center gap-2 rounded-full bg-gradient-to-r from-aurora via-emerald-500 to-sunrise px-6 py-3 text-base font-semibold text-white shadow-[0_20px_45px_-28px_rgba(31,157,109,0.75)] transition hover:brightness-110 dark:bg-aurora dark:text-charcoal dark:shadow-glow dark:hover:bg-neon"
             >
               <FiMail className="text-lg" />
               Falar comigo
@@ -24,7 +27,7 @@ export function Contact() {
               href="https://github.com/DeyvidJesus"
               target="_blank"
               rel="noreferrer"
-              className="group flex items-center gap-2 rounded-full border border-slate-300 dark:border-white/10 bg-slate-100 dark:bg-white/5 px-6 py-3 text-base font-semibold text-slate-900 dark:text-white transition hover:border-aurora dark:hover:border-neon/60 hover:text-aurora dark:hover:text-neon"
+              className="group flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-6 py-3 text-base font-semibold text-slate-900 shadow-[0_18px_35px_-26px_rgba(31,157,109,0.6)] backdrop-blur-sm transition hover:border-aurora hover:text-aurora dark:border-white/10 dark:bg-white/5 dark:text-white dark:hover:border-neon/60 dark:hover:text-neon"
             >
               <FiGithub className="text-lg" />
               GitHub
@@ -33,7 +36,7 @@ export function Contact() {
               href="https://www.linkedin.com/in/deyvid-gondim/"
               target="_blank"
               rel="noreferrer"
-              className="group flex items-center gap-2 rounded-full border border-slate-300 dark:border-white/10 bg-slate-100 dark:bg-white/5 px-6 py-3 text-base font-semibold text-slate-900 dark:text-white transition hover:border-aurora dark:hover:border-neon/60 hover:text-aurora dark:hover:text-neon"
+              className="group flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-6 py-3 text-base font-semibold text-slate-900 shadow-[0_18px_35px_-26px_rgba(31,157,109,0.6)] backdrop-blur-sm transition hover:border-aurora hover:text-aurora dark:border-white/10 dark:bg-white/5 dark:text-white dark:hover:border-neon/60 dark:hover:text-neon"
             >
               <FiLinkedin className="text-lg" />
               LinkedIn

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -58,7 +58,10 @@ const EXPERIENCES = [
 
 export function Experience() {
   return (
-    <section id="experiencias" className="mx-auto max-w-[1440px] px-6 py-24">
+    <section id="experiencias" className="relative mx-auto max-w-[1440px] px-6 py-24">
+      <div className="pointer-events-none absolute inset-y-0 left-4 -z-10 hidden w-2 rounded-full bg-gradient-to-b from-aurora/50 via-sunrise/40 to-skyglass/40 dark:block" />
+      <div className="pointer-events-none absolute inset-x-10 top-12 -z-20 h-[720px] rounded-3xl bg-white/70 blur-3xl dark:hidden" />
+
       <Reveal>
         <div className="flex flex-col gap-4">
           <h2 className="section-title text-slate-900 dark:text-white">Experiências Profissionais</h2>
@@ -68,11 +71,11 @@ export function Experience() {
         </div>
       </Reveal>
 
-      <div className="mt-12 space-y-10 border-l border-slate-300 dark:border-white/10 pl-6 md:pl-10">
+      <div className="mt-12 space-y-10 border-l border-slate-200/70 dark:border-white/10 pl-6 md:pl-10">
         {EXPERIENCES.map((experience, index) => (
           <Reveal key={`${experience.company}-${experience.role}`} delay={index * 120}>
-            <article className="relative rounded-2xl border border-slate-300 dark:border-white/10 bg-slate-50 dark:bg-white/5 p-6 transition hover:border-aurora dark:hover:border-neon/40 hover:shadow-glow dark:hover:shadow-glow">
-              <span className="absolute -left-3 top-6 h-5 w-5 rounded-full border-4 border-white dark:border-charcoal bg-aurora shadow-glow" />
+            <article className="relative overflow-hidden rounded-2xl border border-white/70 bg-white/85 p-6 shadow-aurora backdrop-blur-sm transition hover:-translate-y-1 hover:border-aurora hover:shadow-[0_35px_60px_-35px_rgba(31,157,109,0.55)] dark:border-white/10 dark:bg-white/5 dark:hover:border-neon/40 dark:hover:shadow-glow">
+              <span className="absolute -left-3 top-6 h-5 w-5 rounded-full border-4 border-white bg-gradient-to-br from-aurora to-sunrise shadow-[0_10px_30px_-12px_rgba(31,157,109,0.8)] dark:border-charcoal dark:bg-aurora dark:shadow-glow" />
               <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
                 <h3 className="text-xl font-semibold text-slate-900 dark:text-white">
                   {experience.role}
@@ -84,12 +87,12 @@ export function Experience() {
               <p className="mt-4 text-sm text-slate-700 dark:text-slate/90 md:text-base">{experience.summary}</p>
 
               <ul className="mt-4 space-y-2 text-sm text-slate-700 dark:text-slate/80">
-                {experience.achievements.map(item => (
-                  <li key={item} className="flex items-start gap-2">
-                    <span className="mt-1 h-1.5 w-1.5 rounded-full bg-aurora dark:bg-neon" />
-                    <span>{item}</span>
-                  </li>
-                ))}
+                  {experience.achievements.map(item => (
+                    <li key={item} className="flex items-start gap-2">
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-gradient-to-br from-aurora to-sunrise dark:from-neon dark:to-emerald-400" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
               </ul>
 
               <p className="mt-4 text-xs font-mono uppercase tracking-wide text-aurora/80 dark:text-neon/80">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,20 +26,34 @@ export function Header() {
   return (
     <header
       className={`fixed top-0 inset-x-0 z-50 transition-all duration-500 ${
-        hasShadow 
-          ? 'bg-slate-50/90 dark:bg-charcoal/90 backdrop-blur-lg shadow-glow border-b border-slate-200 dark:border-white/5' 
+        hasShadow
+          ? 'border-b border-slate-200/60 bg-white/85 shadow-[0_18px_40px_-24px_rgba(31,157,109,0.35)] backdrop-blur-xl dark:border-white/5 dark:bg-charcoal/90'
           : 'bg-transparent'
       }`}
     >
+      {hasShadow && (
+        <>
+          <div className="pointer-events-none absolute inset-0 -z-10 bg-light-layer opacity-90 dark:hidden" />
+          <div className="pointer-events-none absolute inset-0 -z-10 hidden bg-gradient-to-b from-charcoal/80 to-night dark:block" />
+        </>
+      )}
       <div className="mx-auto flex max-w-[1440px] items-center justify-between px-6 py-4">
-        <a href="#inicio" className="flex items-center gap-2 text-lg font-semibold tracking-tight text-slate-900 dark:text-white">
-          <span className="rounded-full bg-aurora/15 px-3 py-1 text-sm font-medium text-aurora dark:text-neon">Fullstack</span>
-          <span className="font-serif text-xl">Deyvid Gondim</span>
+        <a href="#inicio" className="flex items-center gap-3 text-lg font-semibold tracking-tight text-slate-900 dark:text-white">
+          <span className="rounded-full bg-gradient-to-r from-aurora/20 via-sunrise/25 to-skyglass/30 px-3 py-1 text-sm font-medium text-aurora dark:text-neon">
+            Fullstack
+          </span>
+          <span className="font-serif text-xl bg-gradient-to-r from-slate-900 via-aurora to-coral bg-clip-text text-transparent dark:bg-none dark:text-white">
+            Deyvid Gondim
+          </span>
         </a>
 
         <nav className="hidden md:flex items-center gap-8 text-sm font-medium text-slate-700 dark:text-slate/90">
           {NAV_ITEMS.map(item => (
-            <a key={item.href} href={item.href} className="link text-slate-700 dark:text-slate/90 hover:text-slate-900 dark:hover:text-white">
+            <a
+              key={item.href}
+              href={item.href}
+              className="link text-slate-700 transition-colors hover:text-aurora dark:text-slate/90 dark:hover:text-neon"
+            >
               {item.label}
             </a>
           ))}
@@ -51,7 +65,7 @@ export function Header() {
             href="https://github.com/DeyvidJesus"
             target="_blank"
             rel="noreferrer"
-            className="rounded-full border border-slate-300 dark:border-white/10 bg-white dark:bg-white/5 text-slate-900 dark:text-slate px-4 py-2 text-sm font-medium hover:border-aurora dark:hover:border-neon/70 dark:hover:text-white hover:shadow-glow transition"
+            className="rounded-full border border-slate-200/70 bg-white/80 px-4 py-2 text-sm font-medium text-slate-800 transition hover:border-aurora hover:text-aurora hover:shadow-aurora dark:border-white/10 dark:bg-white/5 dark:text-slate dark:hover:border-neon/70 dark:hover:text-white"
           >
             GitHub
           </a>
@@ -59,7 +73,7 @@ export function Header() {
             href="https://www.linkedin.com/in/deyvid-gondim/"
             target="_blank"
             rel="noreferrer"
-            className="rounded-full bg-aurora dark:bg-aurora px-5 py-2 text-sm font-semibold text-white dark:text-charcoal transition hover:bg-aurora/90 dark:hover:bg-neon"
+            className="rounded-full bg-gradient-to-r from-aurora via-emerald-500 to-sunrise px-5 py-2 text-sm font-semibold text-white shadow-[0_18px_35px_-22px_rgba(31,157,109,0.65)] transition hover:brightness-110 dark:bg-aurora dark:text-charcoal dark:shadow-glow dark:hover:bg-neon"
           >
             LinkedIn
           </a>

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -19,13 +19,16 @@ const HIGHLIGHTS = [
 export function Main() {
   return (
     <section id="inicio" className="relative overflow-hidden">
-      <div className="absolute inset-0 -z-10 bg-grid bg-grid-pattern opacity-20 dark:opacity-60" />
-      <div className="absolute -left-10 top-16 h-64 w-64 rounded-full bg-aurora/10 dark:bg-aurora/30 blur-3xl" />
-      <div className="absolute -right-10 bottom-10 h-64 w-64 rounded-full bg-aurora/5 dark:bg-neon/20 blur-3xl" />
+      <div className="absolute inset-0 -z-20 bg-gradient-to-b from-white/80 via-skyglass/40 to-transparent dark:from-transparent dark:via-transparent dark:to-transparent" />
+      <div className="absolute inset-0 -z-10 bg-grid bg-grid-pattern opacity-30 dark:opacity-60" />
+      <div className="absolute -left-8 top-24 h-64 w-64 rounded-full bg-[radial-gradient(circle_at_center,_rgba(248,179,123,0.45)_0%,_transparent_60%)] blur-3xl dark:hidden" />
+      <div className="absolute -right-6 bottom-12 h-56 w-56 rounded-full bg-[radial-gradient(circle_at_center,_rgba(79,209,197,0.35)_0%,_transparent_60%)] blur-3xl dark:hidden" />
+      <div className="absolute -left-10 top-16 hidden h-64 w-64 rounded-full bg-aurora/20 blur-3xl dark:block" />
+      <div className="absolute -right-10 bottom-10 hidden h-64 w-64 rounded-full bg-neon/20 blur-3xl dark:block" />
 
       <div className="mx-auto flex min-h-screen max-w-[1440px] flex-col justify-center gap-12 px-6 pb-24 pt-32">
         <Reveal>
-          <span className="inline-flex items-center gap-2 rounded-full border border-slate-300 dark:border-white/10 bg-slate-100 dark:bg-white/5 px-4 py-1 text-sm font-medium text-aurora dark:text-neon">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/70 px-4 py-1 text-sm font-medium text-aurora shadow-[0_14px_28px_-22px_rgba(31,157,109,0.65)] backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:text-neon">
             Desenvolvedor Fullstack · Arquitetura distribuída
           </span>
         </Reveal>
@@ -54,7 +57,7 @@ export function Main() {
             <a
               href="/Deyvid Gondim - Curriculo.pdf"
               download
-              className="group flex items-center gap-2 rounded-full border border-slate-300 dark:border-white/10 bg-slate-100 dark:bg-white/5 px-6 py-3 text-base font-semibold text-slate-900 dark:text-white transition hover:border-aurora dark:hover:border-neon/60 hover:text-aurora dark:hover:text-neon"
+              className="group flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-6 py-3 text-base font-semibold text-slate-900 shadow-[0_18px_38px_-28px_rgba(31,157,109,0.6)] backdrop-blur-sm transition hover:border-aurora hover:text-aurora dark:border-white/10 dark:bg-white/5 dark:text-white dark:hover:border-neon/60 dark:hover:text-neon"
             >
               Baixar CV
               <FiDownload className="transition-transform group-hover:-translate-y-0.5" />
@@ -65,7 +68,8 @@ export function Main() {
         <div className="grid gap-6 md:grid-cols-3">
           {HIGHLIGHTS.map((highlight, index) => (
             <Reveal key={highlight.label} delay={400 + index * 120}>
-              <div className="glass-panel flex h-full flex-col gap-3 rounded-2xl p-6">
+              <div className="glass-panel relative flex h-full flex-col gap-3 overflow-hidden rounded-2xl border border-white/60 bg-white/80 p-6 shadow-aurora backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:shadow-card">
+                <span className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-aurora via-emerald-400 to-sunrise dark:from-neon dark:via-emerald-400 dark:to-aurora" />
                 <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{highlight.label}</h3>
                 <p className="text-sm text-slate-700 dark:text-slate/90">{highlight.description}</p>
               </div>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -64,6 +64,8 @@ const PROJECTS: Project[] = [
 export function Projects() {
   return (
     <section id="projetos" className="relative mx-auto max-w-[1440px] px-6 py-24">
+      <div className="pointer-events-none absolute inset-x-0 top-14 -z-10 h-[480px] rounded-[40px] bg-light-layer opacity-90 blur-2xl dark:hidden" />
+      <div className="pointer-events-none absolute inset-x-10 top-20 -z-10 hidden h-[460px] rounded-[36px] bg-gradient-to-r from-charcoal/80 via-midnight/80 to-charcoal/80 blur-3xl dark:block" />
       <Reveal>
         <div className="flex flex-col gap-4">
           <h2 className="section-title text-slate-900 dark:text-white">Projetos em Destaque</h2>
@@ -76,7 +78,8 @@ export function Projects() {
       <div className="mt-12 grid gap-6 md:grid-cols-2">
         {PROJECTS.map((project, index) => (
           <Reveal key={project.title} delay={index * 120}>
-            <article className="group flex h-full flex-col justify-between rounded-3xl border border-slate-300 dark:border-white/10 bg-slate-50 dark:bg-white/5 p-6 transition hover:border-aurora dark:hover:border-neon/40 hover:shadow-glow dark:hover:shadow-glow">
+            <article className="group relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border border-white/70 bg-white/85 p-6 shadow-aurora backdrop-blur-sm transition hover:-translate-y-1 hover:border-aurora hover:shadow-[0_35px_70px_-35px_rgba(31,157,109,0.55)] dark:border-white/10 dark:bg-white/5 dark:hover:border-neon/40 dark:hover:shadow-glow">
+              <span className="pointer-events-none absolute inset-x-0 top-0 h-[3px] bg-gradient-to-r from-aurora via-emerald-400 to-sunrise opacity-90 transition duration-500 group-hover:scale-x-110 dark:from-neon dark:via-emerald-400 dark:to-aurora" />
               <div>
                 <span className="text-sm font-mono uppercase tracking-wide text-aurora/80 dark:text-neon/80">{project.company}</span>
                 <h3 className="mt-2 text-2xl font-semibold text-slate-900 dark:text-white">{project.title}</h3>
@@ -84,7 +87,7 @@ export function Projects() {
                 <ul className="mt-4 space-y-2 text-sm text-slate-700 dark:text-slate/80">
                   {project.achievements.map(item => (
                     <li key={item} className="flex items-start gap-2">
-                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-aurora dark:bg-neon" />
+                      <span className="mt-1 h-1.5 w-1.5 rounded-full bg-gradient-to-br from-aurora to-sunrise dark:from-neon dark:to-emerald-400" />
                       <span>{item}</span>
                     </li>
                   ))}
@@ -97,7 +100,7 @@ export function Projects() {
                     href={project.link}
                     target="_blank"
                     rel="noreferrer"
-                    className="inline-flex items-center gap-1 text-slate-900 dark:text-white transition hover:text-aurora dark:hover:text-neon"
+                    className="inline-flex items-center gap-1 text-slate-900 transition hover:text-aurora dark:text-white dark:hover:text-neon"
                   >
                     Ver projeto
                     <FiArrowUpRight />

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -22,6 +22,8 @@ const SKILL_GROUPS = [
 export function Skills() {
   return (
     <section id="habilidades" className="relative mx-auto max-w-[1440px] px-6 py-24">
+      <div className="pointer-events-none absolute inset-x-6 top-16 -z-10 h-[420px] rounded-[36px] bg-light-layer opacity-90 blur-2xl dark:hidden" />
+      <div className="pointer-events-none absolute inset-x-12 top-24 -z-10 hidden h-[420px] rounded-[32px] bg-gradient-to-r from-charcoal/85 via-midnight/80 to-charcoal/85 blur-3xl dark:block" />
       <Reveal>
         <div className="flex flex-col gap-4">
           <h2 className="section-title text-slate-900 dark:text-white">Stack & Habilidades</h2>
@@ -34,11 +36,15 @@ export function Skills() {
       <div className="mt-12 grid gap-6 md:grid-cols-2">
         {SKILL_GROUPS.map((group, index) => (
           <Reveal key={group.title} delay={index * 120}>
-            <div className="glass-panel h-full rounded-2xl p-6">
+            <div className="glass-panel relative h-full overflow-hidden rounded-2xl border border-white/70 bg-white/85 p-6 shadow-aurora backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:shadow-card">
+              <span className="pointer-events-none absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-aurora via-emerald-400 to-sunrise dark:from-neon dark:via-emerald-400 dark:to-aurora" />
               <h3 className="text-lg font-semibold text-slate-900 dark:text-white">{group.title}</h3>
               <ul className="mt-4 flex flex-wrap gap-3 text-sm text-slate-700 dark:text-slate/90">
                 {group.items.map(item => (
-                  <li key={item} className="rounded-full border border-slate-300 dark:border-white/10 bg-slate-100 dark:bg-white/5 px-3 py-1 text-xs uppercase tracking-wide text-aurora/80 dark:text-neon/80">
+                  <li
+                    key={item}
+                    className="rounded-full border border-aurora/20 bg-white/80 px-3 py-1 text-xs uppercase tracking-wide text-aurora/80 shadow-[0_12px_24px_-18px_rgba(31,157,109,0.65)] backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:text-neon/80"
+                  >
                     {item}
                   </li>
                 ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,9 +29,11 @@ html.dark body {
 
 /* Tema Claro */
 html:not(.dark) body {
-  background: radial-gradient(circle at 10% 20%, rgba(31, 157, 109, 0.08) 0%, transparent 55%),
-              radial-gradient(circle at 90% 10%, rgba(31, 157, 109, 0.06) 0%, transparent 60%),
-              #ffffff;
+  background:
+    radial-gradient(circle at 12% 18%, rgba(31, 157, 109, 0.18) 0%, transparent 55%),
+    radial-gradient(circle at 82% 12%, rgba(248, 179, 123, 0.25) 0%, transparent 52%),
+    radial-gradient(circle at 50% 86%, rgba(224, 242, 255, 0.5) 0%, transparent 58%),
+    linear-gradient(180deg, #ffffff 0%, #f8fbff 55%, #fff6fb 100%);
   color: #1f2937;
 }
 
@@ -126,9 +128,9 @@ html:not(.dark) *::-webkit-scrollbar-thumb {
 }
 
 html:not(.dark) .glass-panel {
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.85), rgba(240, 248, 255, 0.55));
-  border: 1px solid rgba(31, 157, 109, 0.25);
-  box-shadow: 0 24px 60px -30px rgba(12, 24, 38, 0.1);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(224, 242, 255, 0.75));
+  border: 1px solid rgba(31, 157, 109, 0.2);
+  box-shadow: 0 24px 60px -30px rgba(16, 42, 66, 0.15);
 }
 
 .section-title {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,14 +25,21 @@ export default {
         neon: '#4affc0',
         charcoal: '#1b324a',
         slate: '#c7d6e5',
-        smoke: '#23354b'
+        smoke: '#23354b',
+        sunrise: '#f8b37b',
+        coral: '#ff7f6a',
+        skyglass: '#e0f2ff',
+        blush: '#ffe7f3'
       },
       boxShadow: {
         glow: '0 0 35px rgba(74, 255, 192, 0.2)',
-        card: '0 15px 60px -20px rgba(12, 24, 38, 0.8)'
+        card: '0 15px 60px -20px rgba(12, 24, 38, 0.8)',
+        aurora: '0 20px 45px -25px rgba(31, 157, 109, 0.35)'
       },
       backgroundImage: {
-        'grid': 'linear-gradient(to right, rgba(31, 157, 109, 0.08) 1px, transparent 1px), linear-gradient(to bottom, rgba(31, 157, 109, 0.08) 1px, transparent 1px)'
+        'grid': 'linear-gradient(to right, rgba(31, 157, 109, 0.08) 1px, transparent 1px), linear-gradient(to bottom, rgba(31, 157, 109, 0.08) 1px, transparent 1px)',
+        'light-hero': 'radial-gradient(circle at 15% 20%, rgba(31, 157, 109, 0.18) 0, transparent 45%), radial-gradient(circle at 85% 15%, rgba(248, 179, 123, 0.28) 0, transparent 50%), radial-gradient(circle at 50% 90%, rgba(224, 242, 255, 0.55) 0, transparent 55%)',
+        'light-layer': 'linear-gradient(135deg, rgba(255, 255, 255, 0.85) 0%, rgba(224, 242, 255, 0.9) 35%, rgba(255, 231, 243, 0.8) 100%)'
       },
       backgroundSize: {
         'grid-pattern': '40px 40px'


### PR DESCRIPTION
## Summary
- refresh the global canvas and hero layout with layered gradients to give the light theme more personality
- update portfolio sections with glassmorphic cards, gradient badges, and accent lighting for a livelier presentation
- extend the Tailwind palette with new highlight colors and shadows to support the refreshed visuals

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917467fb7f48331ac38b5d6ec8d1b79)