### PR TITLE
Align portfolio content with verified profile and add language-aware UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,20 @@ import { Skills } from './components/Skills';
 import { Contact } from './components/Contact';
 import BackToTopButton from './components/BackToTopBtn';
 import { ThemeProvider } from './contexts/ThemeContext';
+import { LanguageProvider } from './contexts/LanguageContext';
+import { useLanguage } from './hooks/useLanguage';
 
 function AppContent() {
+  const { language } = useLanguage();
+  const footerCopy =
+    language === 'en'
+      ? 'Built by '
+      : 'Construído por ';
+  const footerRole =
+    language === 'en'
+      ? 'Software Engineer · Full Stack Developer (Backend-focused)'
+      : 'Engenheiro de Software · Desenvolvedor Full Stack (Foco em Backend)';
+
   return (
     <div className="relative min-h-screen overflow-hidden bg-white dark:bg-night text-slate-900 dark:text-white transition-colors duration-300">
       <div className="pointer-events-none absolute inset-0 -z-10">
@@ -31,7 +43,12 @@ function AppContent() {
       </main>
       <footer className="border-t border-slate-200/60 bg-gradient-to-r via-skyglass/70 to-white/90 py-8 text-center text-sm text-slate-600 backdrop-blur-md dark:border-white/5 dark:bg-charcoal/70 dark:text-slate/80">
         <p>
-          Construído por <strong className="bg-gradient-to-r from-aurora via-emerald-500 to-sunrise bg-clip-text text-transparent dark:text-neon">Deyvid Gondim</strong> · Desenvolvedor Fullstack · {new Date().getFullYear()}
+          {footerCopy}
+          <strong className="bg-gradient-to-r from-aurora via-emerald-500 to-sunrise bg-clip-text text-transparent dark:text-neon">Deyvid Gondim</strong>
+          {' · '}
+          {footerRole}
+          {' · '}
+          {new Date().getFullYear()}
         </p>
       </footer>
       <BackToTopButton />
@@ -42,7 +59,9 @@ function AppContent() {
 function App() {
   return (
     <ThemeProvider>
-      <AppContent />
+      <LanguageProvider>
+        <AppContent />
+      </LanguageProvider>
     </ThemeProvider>
   );
 }

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,30 +1,61 @@
 import { Reveal } from './Reveal';
+import { useLanguage } from '../hooks/useLanguage';
 
-const FOCUS_AREAS = [
-  {
-    title: 'Arquitetura orientada a produto',
+const CONTENT = {
+  en: {
+    title: 'Technical Summary',
     description:
-      'Definição de domínios, modelos de dados, contratos e comunicação entre serviços garantindo escalabilidade e governança técnica.'
+      'Software engineer and full stack developer with a backend focus, working across architecture, backend services, and frontend delivery.',
+    focusAreas: [
+      {
+        title: 'Backend ownership',
+        description: 'Java and Spring Boot services, authentication, authorization, and core business logic.'
+      },
+      {
+        title: 'Frontend delivery',
+        description: 'React and TypeScript applications with production-focused UI work.'
+      },
+      {
+        title: 'Infrastructure and delivery',
+        description: 'Docker deployments, CI/CD workflows, and cloud/VPS environments.'
+      }
+    ],
+    stats: [
+      { value: '3+ years', label: 'professional experience' },
+      { value: 'Remote-ready', label: 'Brazil · US roles' },
+      { value: 'Full stack', label: 'Java · Spring Boot · React · Next.js · PostgreSQL · Docker' }
+    ]
   },
-  {
-    title: 'Experiências web premium',
+  pt: {
+    title: 'Resumo Técnico',
     description:
-      'Componentes reutilizáveis, SSR/SSG com Next.js, design systems e interfaces responsivas otimizadas para performance e SEO.'
-  },
-  {
-    title: 'Automação e observabilidade',
-    description:
-      'Pipelines CI/CD, monitoramento, logs estruturados, testes e métricas para garantir entregas contínuas com segurança.'
+      'Engenheiro de software e desenvolvedor full stack com foco em backend, atuando em arquitetura, serviços backend e entrega frontend.',
+    focusAreas: [
+      {
+        title: 'Ownership de backend',
+        description: 'Serviços em Java e Spring Boot, autenticação, autorização e lógica de negócio.'
+      },
+      {
+        title: 'Entrega frontend',
+        description: 'Aplicações em React e TypeScript com foco em produção.'
+      },
+      {
+        title: 'Infraestrutura e entrega',
+        description: 'Deploys com Docker, fluxos de CI/CD e ambientes cloud/VPS.'
+      }
+    ],
+    stats: [
+      { value: '3+ anos', label: 'de experiência profissional' },
+      { value: 'Remoto', label: 'Brasil · vagas nos EUA' },
+      { value: 'Full stack', label: 'Java · Spring Boot · React · Next.js · PostgreSQL · Docker' }
+    ]
   }
-];
-
-const SUMMARY_STATS = [
-  { value: '4 produtos', label: 'lançados do zero, com entregas contínuas' },
-  { value: '10+ integrações', label: 'entre APIs, microsserviços e automações internas' },
-  { value: 'Stack completa', label: 'React · Next.js · Node.js · Python · Java · Spring Boot · Docker' }
-];
+};
 
 export function About() {
+  const { language } = useLanguage();
+  const content = CONTENT[language];
+
   return (
     <section id="resumo" className="relative mx-auto max-w-[1440px] px-6 py-24">
       <div className="pointer-events-none absolute inset-x-4 top-10 -z-10 h-[420px] rounded-3xl bg-light-layer opacity-80 blur-2xl dark:hidden" />
@@ -33,14 +64,14 @@ export function About() {
       <Reveal>
         <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
           <div className="max-w-3xl">
-            <h2 className="section-title text-slate-900 dark:text-white">Resumo Profissional</h2>
+            <h2 className="section-title text-slate-900 dark:text-white">{content.title}</h2>
             <p className="mt-4 text-base text-slate-700 dark:text-slate/90 md:text-lg">
-              Desenvolvedor fullstack com experiência prática em todo o ciclo de produtos digitais. Lidero arquiteturas distribuídas, construo interfaces modernas e orquestro deploys seguros em ambientes conteinerizados. Atuo tanto em squads multidisciplinares quanto liderando iniciativas de ponta a ponta.
+              {content.description}
             </p>
           </div>
           <div className="glass-panel relative grid gap-4 overflow-hidden rounded-2xl p-6 shadow-aurora md:w-80">
             <span className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-aurora via-emerald-400 to-sunrise dark:from-neon dark:via-emerald-400 dark:to-aurora" />
-            {SUMMARY_STATS.map(stat => (
+            {content.stats.map(stat => (
               <div key={stat.label}>
                 <span className="text-xl font-semibold text-aurora dark:text-neon">{stat.value}</span>
                 <p className="text-sm text-slate-700 dark:text-slate/90">{stat.label}</p>
@@ -51,7 +82,7 @@ export function About() {
       </Reveal>
 
       <div className="mt-12 grid gap-6 md:grid-cols-3">
-        {FOCUS_AREAS.map((focus, index) => (
+        {content.focusAreas.map((focus, index) => (
           <Reveal key={focus.title} delay={150 * index}>
             <article className="glass-panel relative h-full overflow-hidden rounded-2xl border border-white/60 bg-white/85 p-6 shadow-aurora backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:shadow-card">
               <span className="pointer-events-none absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-aurora via-sunrise to-skyglass dark:from-neon dark:via-emerald-400 dark:to-aurora" />

--- a/src/components/BackToTopBtn.tsx
+++ b/src/components/BackToTopBtn.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useState } from 'react';
 import { FiArrowUp } from 'react-icons/fi';
+import { useLanguage } from '../hooks/useLanguage';
 
 const BackToTopButton = () => {
   const [isVisible, setIsVisible] = useState(false);
+  const { language } = useLanguage();
+  const label = language === 'en' ? 'Back to top' : 'Voltar ao topo';
 
   useEffect(() => {
     const handleScroll = () => {
@@ -26,7 +29,7 @@ const BackToTopButton = () => {
   return (
     <button
       id="backToTopBtn"
-      title="Voltar ao topo"
+      title={label}
       onClick={scrollToTop}
       className={`fixed bottom-6 right-6 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-aurora text-white dark:text-charcoal shadow-glow transition-all hover:bg-aurora/90 dark:hover:bg-neon ${
         isVisible ? 'opacity-100' : 'pointer-events-none opacity-0'

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,7 +1,26 @@
 import { FiGithub, FiLinkedin, FiMail } from 'react-icons/fi';
 import { Reveal } from './Reveal';
+import { useLanguage } from '../hooks/useLanguage';
 
 export function Contact() {
+  const { language } = useLanguage();
+  const content = {
+    en: {
+      eyebrow: 'Next step',
+      title: 'Ready to accelerate your next product?',
+      description:
+        'I’m ready to support everything from architecture design to the implementation of critical features. Reach out so we can build complete solutions with quality, security, and a scaling rhythm.',
+      cta: 'Let’s talk'
+    },
+    pt: {
+      eyebrow: 'Próximo passo',
+      title: 'Vamos acelerar seu próximo produto?',
+      description:
+        'Estou pronto para apoiar desde a concepção da arquitetura até a implementação de features críticas. Entre em contato para construirmos soluções completas com qualidade, segurança e ritmo de escala.',
+      cta: 'Falar comigo'
+    }
+  }[language];
+
   return (
     <section id="contato" className="relative mx-auto max-w-[1440px] px-6 py-24">
       <div className="pointer-events-none absolute inset-x-8 top-12 -z-10 h-[360px] rounded-[32px] bg-light-layer opacity-95 blur-2xl dark:hidden" />
@@ -9,10 +28,10 @@ export function Contact() {
       <Reveal>
         <div className="glass-panel relative overflow-hidden rounded-3xl border border-white/70 bg-white/90 p-10 text-center shadow-aurora backdrop-blur-lg dark:border-white/10 dark:bg-white/5 dark:shadow-card">
           <span className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-aurora via-emerald-400 to-sunrise dark:from-neon dark:via-emerald-400 dark:to-aurora" />
-          <span className="text-sm font-mono uppercase tracking-[0.3em] text-aurora/70 dark:text-neon/70">Próximo passo</span>
-          <h2 className="mt-4 text-3xl font-semibold text-slate-900 dark:text-white md:text-4xl">Vamos acelerar seu próximo produto?</h2>
+          <span className="text-sm font-mono uppercase tracking-[0.3em] text-aurora/70 dark:text-neon/70">{content.eyebrow}</span>
+          <h2 className="mt-4 text-3xl font-semibold text-slate-900 dark:text-white md:text-4xl">{content.title}</h2>
           <p className="mx-auto mt-4 max-w-3xl text-base text-slate-700 dark:text-slate/90 md:text-lg">
-            Estou pronto para apoiar desde a concepção da arquitetura até a implementação de features críticas. Entre em contato para construirmos soluções completas com qualidade, segurança e ritmo de escala.
+            {content.description}
           </p>
 
           <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
@@ -21,7 +40,7 @@ export function Contact() {
               className="group flex items-center gap-2 rounded-full bg-gradient-to-r from-aurora via-emerald-500 to-sunrise px-6 py-3 text-base font-semibold text-white shadow-[0_20px_45px_-28px_rgba(31,157,109,0.75)] transition hover:brightness-110 dark:bg-aurora dark:text-charcoal dark:shadow-glow dark:hover:bg-neon"
             >
               <FiMail className="text-lg" />
-              Falar comigo
+              {content.cta}
             </a>
             <a
               href="https://github.com/DeyvidJesus"

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,62 +1,119 @@
 import { Reveal } from './Reveal';
+import { useLanguage } from '../hooks/useLanguage';
 
-const EXPERIENCES = [
-  {
-    company: 'GoMech',
-    role: 'Desenvolvedor Fullstack',
-    period: '2024 – atual',
-    summary:
-      'Responsável por toda a arquitetura do SaaS multi-tenant de gestão de oficinas, cobrindo frontend, backend, IA e infraestrutura.',
-    achievements: [
-      'Arquitetura completa com módulos de clientes, veículos, estoque, financeiro, conversas, relatórios e IA.',
-      'Implementação de microsserviço de IA com agentes SQL, Chat, Router e Charts conectados ao banco principal.',
-      'Automação de deploy com Docker, Nginx, VPS e pipelines contínuos, garantindo segurança e escalabilidade.'
-    ],
-    technologies:
-      'React 19, TypeScript, Vite, TanStack Router/Query, Tailwind, Java, Spring Boot, FastAPI, LangChain, PostgreSQL, Docker, Nginx'
+const CONTENT = {
+  en: {
+    title: 'Professional Experience',
+    subtitle:
+      'Backend ownership, architecture, and production delivery across SaaS and enterprise ecommerce.',
+    experiences: [
+      {
+        company: 'GoMech',
+        role: 'Co-Founder & Software Engineer',
+        period: 'Jul 2025 – present',
+        summary:
+          'Co-founded the product and owned the technical architecture for an automotive service management SaaS.',
+        achievements: [
+          'Built backend services with Java and Spring Boot.',
+          'Implemented authentication, authorization, and core business logic.',
+          'Designed and maintained PostgreSQL data models.',
+          'Built frontend applications with React and TypeScript.',
+          'Deployed services with Docker on cloud/VPS infrastructure.',
+          'Owned technical decisions, feature delivery, and system evolution.'
+        ],
+        technologies:
+          'Java · Spring Boot · PostgreSQL · React · TypeScript · Docker'
+      },
+      {
+        company: 'Econverse',
+        role: 'Frontend / Full Stack Developer',
+        period: 'Mar 2025 – present',
+        summary:
+          'Worked on an enterprise ecommerce platform, building frontend and backend features for production applications.',
+        achievements: [
+          'Developed and maintained high-traffic production applications.',
+          'Built and integrated backend services with Node.js and GraphQL.',
+          'Worked extensively with React, Next.js, and TypeScript.',
+          'Improved performance, reliability, and developer experience.',
+          'Collaborated with product, backend, and business teams.',
+          'Participated in code reviews and agile ceremonies.'
+        ],
+        technologies: 'React · Next.js · TypeScript · Node.js · GraphQL · SASS · Tailwind CSS'
+      },
+      {
+        company: 'Econverse',
+        role: 'Frontend Developer Intern',
+        period: 'Jun 2024 – Mar 2025',
+        summary:
+          'Built UI components and integrated APIs as part of agile delivery.',
+        achievements: [
+          'Built responsive UI components with React, HTML, CSS, and SASS.',
+          'Integrated REST APIs.',
+          'Worked in agile teams (planning, reviews, retrospectives).'
+        ],
+        technologies: 'React · JavaScript · HTML · CSS · SASS · REST APIs'
+      }
+    ]
   },
-  {
-    company: 'Econverse',
-    role: 'Desenvolvedor Frontend Júnior',
-    period: 'mar 2025 – atual',
-    summary:
-      'Atuação na evolução técnica de plataformas completas como NKStore e Alphabeto, criando experiências performáticas e escaláveis.',
-    achievements: [
-      'Reestruturação de componentes, rotas dinâmicas e integrações internas com foco em performance.',
-      'Construção de APIs e serviços Node.js para automações e comunicação entre módulos.',
-      'Entrega de landing pages otimizadas para SEO, responsividade e carregamento rápido.'
-    ],
-    technologies: 'React, Next.js, TypeScript, Node.js, Tailwind, SASS, arquitetura SPA/SSR'
-  },
-  {
-    company: 'Econverse',
-    role: 'Estagiário em Desenvolvimento Frontend',
-    period: 'jun 2024 – mar 2025',
-    summary:
-      'Suporte no desenvolvimento de interfaces e componentes reutilizáveis para projetos de médio e grande porte.',
-    achievements: [
-      'Implementação de componentes responsivos em projetos como NKStore e Alphabeto.',
-      'Colaboração em fluxos dinâmicos, navegação e integrações com APIs REST.',
-      'Desenvolvimento de funcionalidades internas com Node.js seguindo boas práticas de UX.'
-    ],
-    technologies: 'React, TypeScript, JavaScript, Node.js, HTML5, CSS3, SASS, APIs REST'
-  },
-  {
-    company: 'Projetos Freelancer',
-    role: 'Desenvolvedor Frontend',
-    period: 'ago 2023 – jun 2024',
-    summary:
-      'Criação de aplicações, dashboards e landing pages sob medida para clientes de segmentos variados.',
-    achievements: [
-      'Desenvolvimento end-to-end, da prototipação à publicação.',
-      'Implementação de lógicas de negócio, dashboards e integrações personalizadas.',
-      'Interfaces responsivas com foco em acessibilidade, performance e SEO.'
-    ],
-    technologies: 'React, TypeScript, Tailwind, PHP, MySQL, HTML, CSS'
+  pt: {
+    title: 'Experiências Profissionais',
+    subtitle:
+      'Ownership de backend, arquitetura e entrega em produção em SaaS e ecommerce enterprise.',
+    experiences: [
+      {
+        company: 'GoMech',
+        role: 'Co-Fundador & Engenheiro de Software',
+        period: 'jul 2025 – atual',
+        summary:
+          'Co-fundei o produto e assumi a arquitetura técnica de um SaaS de gestão automotiva.',
+        achievements: [
+          'Construí serviços backend com Java e Spring Boot.',
+          'Implementei autenticação, autorização e lógica de negócio.',
+          'Modelei e mantive dados relacionais em PostgreSQL.',
+          'Desenvolvi aplicações frontend com React e TypeScript.',
+          'Realizei deploys com Docker em infraestrutura cloud/VPS.',
+          'Assumi decisões técnicas, entrega de features e evolução do sistema.'
+        ],
+        technologies:
+          'Java · Spring Boot · PostgreSQL · React · TypeScript · Docker'
+      },
+      {
+        company: 'Econverse',
+        role: 'Desenvolvedor Frontend / Full Stack',
+        period: 'mar 2025 – atual',
+        summary:
+          'Atuação em plataforma enterprise de ecommerce com entregas frontend e backend em produção.',
+        achievements: [
+          'Desenvolvi e mantive aplicações de alto tráfego em produção.',
+          'Construí e integrei serviços backend com Node.js e GraphQL.',
+          'Trabalhei com React, Next.js e TypeScript.',
+          'Melhorei performance, confiabilidade e experiência de desenvolvimento.',
+          'Colaborei com times de produto, backend e negócio.',
+          'Participei de code reviews e cerimônias ágeis.'
+        ],
+        technologies: 'React · Next.js · TypeScript · Node.js · GraphQL · SASS · Tailwind CSS'
+      },
+      {
+        company: 'Econverse',
+        role: 'Estagiário em Desenvolvimento Frontend',
+        period: 'jun 2024 – mar 2025',
+        summary:
+          'Construção de componentes de UI e integrações com APIs em times ágeis.',
+        achievements: [
+          'Criei componentes responsivos com React, HTML, CSS e SASS.',
+          'Integrei APIs REST.',
+          'Atuei em times ágeis (planning, reviews, retrospectives).'
+        ],
+        technologies: 'React · JavaScript · HTML · CSS · SASS · APIs REST'
+      }
+    ]
   }
-];
+};
 
 export function Experience() {
+  const { language } = useLanguage();
+  const content = CONTENT[language];
+
   return (
     <section id="experiencias" className="relative mx-auto max-w-[1440px] px-6 py-24">
       <div className="pointer-events-none absolute inset-y-0 left-4 -z-10 hidden w-2 rounded-full bg-gradient-to-b from-aurora/50 via-sunrise/40 to-skyglass/40 dark:block" />
@@ -64,15 +121,15 @@ export function Experience() {
 
       <Reveal>
         <div className="flex flex-col gap-4">
-          <h2 className="section-title text-slate-900 dark:text-white">Experiências Profissionais</h2>
+          <h2 className="section-title text-slate-900 dark:text-white">{content.title}</h2>
           <p className="section-subtitle">
-            Liderança técnica, evolução arquitetural e entrega de produtos completos para diferentes contextos de negócio.
+            {content.subtitle}
           </p>
         </div>
       </Reveal>
 
       <div className="mt-12 space-y-10 border-l border-slate-200/70 dark:border-white/10 pl-6 md:pl-10">
-        {EXPERIENCES.map((experience, index) => (
+        {content.experiences.map((experience, index) => (
           <Reveal key={`${experience.company}-${experience.role}`} delay={index * 120}>
             <article className="relative overflow-hidden rounded-2xl border border-white/70 bg-white/85 p-6 shadow-aurora backdrop-blur-sm transition hover:-translate-y-1 hover:border-aurora hover:shadow-[0_35px_60px_-35px_rgba(31,157,109,0.55)] dark:border-white/10 dark:bg-white/5 dark:hover:border-neon/40 dark:hover:shadow-glow">
               <span className="absolute -left-3 top-6 h-5 w-5 rounded-full border-4 border-white bg-gradient-to-br from-aurora to-sunrise shadow-[0_10px_30px_-12px_rgba(31,157,109,0.8)] dark:border-charcoal dark:bg-aurora dark:shadow-glow" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,18 +1,32 @@
 import { useEffect, useState } from 'react';
 import { ResponsiveMenu } from './ResponsiveMenu';
 import { ThemeToggle } from './ThemeToggle';
+import { LanguageToggle } from './LanguageToggle';
+import { useLanguage } from '../hooks/useLanguage';
 
-const NAV_ITEMS = [
-  { label: 'Início', href: '#inicio' },
-  { label: 'Resumo', href: '#resumo' },
-  { label: 'Experiências', href: '#experiencias' },
-  { label: 'Projetos', href: '#projetos' },
-  { label: 'Habilidades', href: '#habilidades' },
-  { label: 'Contato', href: '#contato' }
-];
+const NAV_ITEMS = {
+  en: [
+    { label: 'Home', href: '#inicio' },
+    { label: 'Summary', href: '#resumo' },
+    { label: 'Experience', href: '#experiencias' },
+    { label: 'Projects', href: '#projetos' },
+    { label: 'Skills', href: '#habilidades' },
+    { label: 'Contact', href: '#contato' }
+  ],
+  pt: [
+    { label: 'Início', href: '#inicio' },
+    { label: 'Resumo', href: '#resumo' },
+    { label: 'Experiências', href: '#experiencias' },
+    { label: 'Projetos', href: '#projetos' },
+    { label: 'Habilidades', href: '#habilidades' },
+    { label: 'Contato', href: '#contato' }
+  ]
+};
 
 export function Header() {
   const [hasShadow, setHasShadow] = useState(false);
+  const { language } = useLanguage();
+  const navItems = NAV_ITEMS[language];
 
   useEffect(() => {
     const handleScroll = () => {
@@ -48,7 +62,7 @@ export function Header() {
         </a>
 
         <nav className="hidden md:flex items-center gap-8 text-sm font-medium text-slate-700 dark:text-slate/90">
-          {NAV_ITEMS.map(item => (
+          {navItems.map(item => (
             <a
               key={item.href}
               href={item.href}
@@ -60,6 +74,7 @@ export function Header() {
         </nav>
 
         <div className="hidden md:flex items-center gap-3">
+          <LanguageToggle />
           <ThemeToggle />
           <a
             href="https://github.com/DeyvidJesus"
@@ -79,7 +94,7 @@ export function Header() {
           </a>
         </div>
 
-        <ResponsiveMenu items={NAV_ITEMS} />
+        <ResponsiveMenu items={navItems} />
       </div>
     </header>
   );

--- a/src/components/LanguageToggle.tsx
+++ b/src/components/LanguageToggle.tsx
@@ -1,0 +1,22 @@
+import { useLanguage } from '../hooks/useLanguage';
+
+const LANGUAGE_LABELS = {
+  en: { label: 'EN', next: 'PT', aria: 'Switch language to Portuguese' },
+  pt: { label: 'PT', next: 'EN', aria: 'Mudar idioma para inglês' }
+};
+
+export function LanguageToggle() {
+  const { language, toggleLanguage } = useLanguage();
+  const labels = LANGUAGE_LABELS[language];
+
+  return (
+    <button
+      onClick={toggleLanguage}
+      className="rounded-full border border-slate-200/70 bg-white/80 px-3 py-2 text-xs font-semibold uppercase tracking-wider text-slate-700 transition hover:border-aurora hover:text-aurora dark:border-white/10 dark:bg-white/5 dark:text-slate/80 dark:hover:border-neon/60 dark:hover:text-neon"
+      aria-label={labels.aria}
+      title={labels.aria}
+    >
+      {labels.next}
+    </button>
+  );
+}

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -1,23 +1,63 @@
 import { FiArrowUpRight, FiDownload } from 'react-icons/fi';
 import { Reveal } from './Reveal';
 import type { MouseEvent } from 'react';
+import { useLanguage } from '../hooks/useLanguage';
 
-const HIGHLIGHTS = [
-  {
-    label: 'SaaS multi-tenant end-to-end',
-    description: 'Arquitetura completa, microsserviços de IA, deploy em Docker/Nginx e governança técnica.'
-  },
-  {
-    label: 'APIs e microsserviços escaláveis',
-    description: 'Domínio de React, Next.js, Java, Spring Boot, Node.js e Python para produtos prontos para produção.'
-  },
-  {
-    label: 'Governança & performance',
-    description: 'CI/CD, observabilidade, LGPD, ISO 38500 e práticas de segurança aplicadas em projetos reais.'
-  }
-];
+const HIGHLIGHTS = {
+  en: [
+    {
+      label: 'Backend-focused full stack delivery',
+      description: 'Architecture ownership, Java/Spring Boot services, and core business logic for SaaS products.'
+    },
+    {
+      label: 'Production web applications',
+      description: 'React, Next.js, and TypeScript interfaces built alongside backend integrations.'
+    },
+    {
+      label: 'Infrastructure and delivery',
+      description: 'Docker deployments, CI/CD workflows, and cloud/VPS environments.'
+    }
+  ],
+  pt: [
+    {
+      label: 'Entrega full stack com foco em backend',
+      description: 'Arquitetura técnica, serviços em Java/Spring Boot e lógica de negócio para SaaS.'
+    },
+    {
+      label: 'Aplicações web em produção',
+      description: 'Interfaces em React, Next.js e TypeScript com integrações de backend.'
+    },
+    {
+      label: 'Infraestrutura e entrega',
+      description: 'Deploys com Docker, fluxos de CI/CD e ambientes cloud/VPS.'
+    }
+  ]
+};
 
 export function Main() {
+  const { language } = useLanguage();
+  const highlights = HIGHLIGHTS[language];
+  const content = {
+    en: {
+      badge: 'Software Engineer · Full Stack Developer (Backend-focused)',
+      headline: 'I build SaaS products and production applications with backend ownership and full stack delivery.',
+      summary:
+        'I work across architecture, backend services, and frontend experiences to deliver reliable software in production.',
+      cta: 'Let’s work together',
+      download: 'Download Resume',
+      filename: 'Deyvid-Gondim-Resume.pdf'
+    },
+    pt: {
+      badge: 'Engenheiro de Software · Desenvolvedor Full Stack (Foco em Backend)',
+      headline: 'Construo produtos SaaS e aplicações em produção com foco em backend e entrega full stack.',
+      summary:
+        'Atuo entre arquitetura, serviços de backend e experiências frontend para entregar software confiável em produção.',
+      cta: 'Vamos trabalhar juntos',
+      download: 'Baixar CV',
+      filename: 'Deyvid-Gondim-Curriculo.pdf'
+    }
+  }[language];
+
   // tenta forçar o download do PDF (fallback para abrir em nova aba)
   const downloadResume = async (e: MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
@@ -36,7 +76,7 @@ export function Main() {
       const blobUrl = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = blobUrl;
-      a.download = 'Deyvid-Gondim-Curriculo.pdf';
+      a.download = content.filename;
       document.body.appendChild(a);
       a.click();
       a.remove();
@@ -59,19 +99,19 @@ export function Main() {
       <div className="mx-auto flex min-h-screen max-w-[1440px] flex-col justify-center gap-12 px-6 pb-24 pt-32">
         <Reveal>
           <span className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/70 px-4 py-1 text-sm font-medium text-aurora shadow-[0_14px_28px_-22px_rgba(31,157,109,0.65)] backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:text-neon">
-            Desenvolvedor Fullstack · Arquitetura distribuída
+            {content.badge}
           </span>
         </Reveal>
 
         <Reveal delay={100}>
           <h1 className="max-w-6xl text-4xl font-semibold leading-tight text-slate-900 dark:text-white md:text-6xl">
-            Construo experiências digitais completas — do design da interface aos microsserviços em produção.
+            {content.headline}
           </h1>
         </Reveal>
 
         <Reveal delay={200}>
           <p className="max-w-4xl text-lg text-slate-700 dark:text-slate/90 md:text-xl">
-            Eu ajudo empresas a lançarem e escalarem produtos. Lidero arquiteturas modernas, crio interfaces de alta performance e integro serviços confiáveis em ambientes conteinerizados.
+            {content.summary}
           </p>
         </Reveal>
 
@@ -81,23 +121,23 @@ export function Main() {
               href="mailto:deyvidgondim@outlook.com"
               className="group flex items-center gap-2 rounded-full bg-aurora px-6 py-3 text-base font-semibold text-white dark:text-charcoal transition hover:bg-aurora/90 dark:hover:bg-neon"
             >
-              Vamos construir juntos
+              {content.cta}
               <FiArrowUpRight className="transition-transform group-hover:translate-x-1 group-hover:-translate-y-1" />
             </a>
             <a
               href={encodeURI('/resume.pdf')}
               onClick={downloadResume}
-              download="Deyvid-Gondim-Curriculo.pdf"
+              download={content.filename}
               className="group flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-6 py-3 text-base font-semibold text-slate-900 shadow-[0_18px_38px_-28px_rgba(31,157,109,0.6)] backdrop-blur-sm transition hover:border-aurora hover:text-aurora dark:border-white/10 dark:bg-white/5 dark:text-white dark:hover:border-neon/60 dark:hover:text-neon"
             >
-              Baixar CV
+              {content.download}
               <FiDownload className="transition-transform group-hover:-translate-y-0.5" />
             </a>
           </div>
         </Reveal>
 
         <div className="grid gap-6 md:grid-cols-3">
-          {HIGHLIGHTS.map((highlight, index) => (
+          {highlights.map((highlight, index) => (
             <Reveal key={highlight.label} delay={400 + index * 120}>
               <div className="glass-panel relative flex h-full flex-col gap-3 overflow-hidden rounded-2xl border border-white/60 bg-white/80 p-6 shadow-aurora backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:shadow-card">
                 <span className="pointer-events-none absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-aurora via-emerald-400 to-sunrise dark:from-neon dark:via-emerald-400 dark:to-aurora" />

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,5 +1,6 @@
 import { FiArrowUpRight } from 'react-icons/fi';
 import { Reveal } from './Reveal';
+import { useLanguage } from '../hooks/useLanguage';
 
 type Project = {
   title: string;
@@ -10,73 +11,100 @@ type Project = {
   link?: string;
 };
 
-const PROJECTS: Project[] = [
-  {
-    title: 'GoMech Platform',
-    company: 'GoMech',
-    description:
-      'SaaS multi-tenant completo para gestão de oficinas com módulos administrativos, operações, comunicação e relatórios inteligentes.',
-    achievements: [
-      'Arquitetura fullstack com React 19, Vite, TanStack, Java/Spring Boot e PostgreSQL.',
-      'Microsserviço de IA para análises SQL, conversas contextuais e relatórios visuais.',
-      'Infraestrutura conteinerizada com Docker, Nginx, pipelines contínuos e governança ISO/LGPD.'
-    ],
-    stack: 'React · TypeScript · TanStack · Java · Spring Boot · FastAPI · LangChain · PostgreSQL · Docker · Nginx'
+const CONTENT: Record<'en' | 'pt', { title: string; subtitle: string; projects: Project[] }> = {
+  en: {
+    title: 'Featured Projects',
+    subtitle:
+      'SaaS and enterprise ecommerce projects with production backend and frontend delivery.',
+    projects: [
+      {
+        title: 'GoMech',
+        company: 'GoMech',
+        description:
+          'SaaS product for automotive service management with backend ownership and full stack delivery.',
+        achievements: [
+          'Owned technical architecture and system evolution.',
+          'Built Java and Spring Boot backend services with authentication, authorization, and core business logic.',
+          'Designed and maintained PostgreSQL data models.',
+          'Built React and TypeScript frontend applications.',
+          'Deployed services with Docker on cloud/VPS infrastructure.'
+        ],
+        stack: 'Java · Spring Boot · PostgreSQL · React · TypeScript · Docker'
+      },
+      {
+        title: 'Econverse Platform',
+        company: 'Econverse',
+        description:
+          'Enterprise ecommerce platform with production frontend and backend development.',
+        achievements: [
+          'Developed and maintained high-traffic production applications.',
+          'Built and integrated backend services with Node.js and GraphQL.',
+          'Worked extensively with React, Next.js, and TypeScript.',
+          'Improved performance, reliability, and developer experience.',
+          'Collaborated with product, backend, and business teams.',
+          'Participated in code reviews and agile ceremonies.'
+        ],
+        stack: 'React · Next.js · TypeScript · Node.js · GraphQL · SASS · Tailwind CSS'
+      }
+    ]
   },
-  {
-    title: 'NKStore',
-    company: 'Econverse',
-    description:
-      'E-commerce escalável com arquitetura modular, componentes reutilizáveis e foco em performance e SEO.',
-    achievements: [
-      'Refatoração de componentes críticos, rotas dinâmicas e integrações internas.',
-      'Automação de fluxos com serviços Node.js e padronização de código.',
-      'Melhorias de SEO, acessibilidade e métricas Core Web Vitals.'
-    ],
-    stack: 'Next.js · React · TypeScript · Node.js · Tailwind · SASS · APIs internas'
-  },
-  {
-    title: 'Alphabeto',
-    company: 'Econverse',
-    description:
-      'Experiência digital completa com vitrines personalizadas, integrações internas e fluxo de conteúdo dinâmico.',
-    achievements: [
-      'Criação de componentes escaláveis alinhados ao design system.',
-      'Integrações com APIs internas e serviços de conteúdo.',
-      'Landing pages institucionais com carregamento rápido e responsividade total.'
-    ],
-    stack: 'React · Next.js · TypeScript · Node.js · Tailwind · SEO'
-  },
-  {
-    title: 'Automations & Dashboards',
-    company: 'Projetos Freelancer',
-    description:
-      'Soluções personalizadas para clientes corporativos envolvendo dashboards, landing pages e integrações.',
-    achievements: [
-      'Automação de fluxos de dados com Node.js, PHP e Python.',
-      'Integração com serviços de pagamento, CRM e mensageria.',
-      'Design responsivo com foco em acessibilidade e UX.'
-    ],
-    stack: 'React · TypeScript · Tailwind · PHP · MySQL · Automação com Node.js/Python'
+  pt: {
+    title: 'Projetos em Destaque',
+    subtitle:
+      'Projetos SaaS e ecommerce enterprise com entrega em produção de backend e frontend.',
+    projects: [
+      {
+        title: 'GoMech',
+        company: 'GoMech',
+        description:
+          'Produto SaaS para gestão automotiva com ownership de backend e entrega full stack.',
+        achievements: [
+          'Assumi arquitetura técnica e evolução do sistema.',
+          'Construí serviços backend em Java e Spring Boot com autenticação, autorização e lógica de negócio.',
+          'Modelei e mantive dados relacionais em PostgreSQL.',
+          'Desenvolvi aplicações frontend em React e TypeScript.',
+          'Realizei deploys com Docker em infraestrutura cloud/VPS.'
+        ],
+        stack: 'Java · Spring Boot · PostgreSQL · React · TypeScript · Docker'
+      },
+      {
+        title: 'Plataforma Econverse',
+        company: 'Econverse',
+        description:
+          'Plataforma enterprise de ecommerce com entregas frontend e backend em produção.',
+        achievements: [
+          'Desenvolvi e mantive aplicações de alto tráfego em produção.',
+          'Construí e integrei serviços backend com Node.js e GraphQL.',
+          'Trabalhei com React, Next.js e TypeScript.',
+          'Melhorei performance, confiabilidade e experiência de desenvolvimento.',
+          'Colaborei com times de produto, backend e negócio.',
+          'Participei de code reviews e cerimônias ágeis.'
+        ],
+        stack: 'React · Next.js · TypeScript · Node.js · GraphQL · SASS · Tailwind CSS'
+      }
+    ]
   }
-];
+};
 
 export function Projects() {
+  const { language } = useLanguage();
+  const content = CONTENT[language];
+
   return (
     <section id="projetos" className="relative mx-auto max-w-[1440px] px-6 py-24">
       <div className="pointer-events-none absolute inset-x-0 top-14 -z-10 h-[480px] rounded-[40px] bg-light-layer opacity-90 blur-2xl dark:hidden" />
       <div className="pointer-events-none absolute inset-x-10 top-20 -z-10 hidden h-[460px] rounded-[36px] bg-gradient-to-r from-charcoal/80 via-midnight/80 to-charcoal/80 blur-3xl dark:block" />
       <Reveal>
         <div className="flex flex-col gap-4">
-          <h2 className="section-title text-slate-900 dark:text-white">Projetos em Destaque</h2>
+          <h2 className="section-title text-slate-900 dark:text-white">{content.title}</h2>
           <p className="section-subtitle">
-            Produtos end-to-end, evolução de e-commerces de alta demanda e automações que conectam times e processos.
+            {content.subtitle}
           </p>
         </div>
       </Reveal>
 
       <div className="mt-12 grid gap-6 md:grid-cols-2">
-        {PROJECTS.map((project, index) => (
+        {content.projects.map((project, index) => (
           <Reveal key={project.title} delay={index * 120}>
             <article className="group relative flex h-full flex-col justify-between overflow-hidden rounded-3xl border border-white/70 bg-white/85 p-6 shadow-aurora backdrop-blur-sm transition hover:-translate-y-1 hover:border-aurora hover:shadow-[0_35px_70px_-35px_rgba(31,157,109,0.55)] dark:border-white/10 dark:bg-white/5 dark:hover:border-neon/40 dark:hover:shadow-glow">
               <span className="pointer-events-none absolute inset-x-0 top-0 h-[3px] bg-gradient-to-r from-aurora via-emerald-400 to-sunrise opacity-90 transition duration-500 group-hover:scale-x-110 dark:from-neon dark:via-emerald-400 dark:to-aurora" />
@@ -102,7 +130,7 @@ export function Projects() {
                     rel="noreferrer"
                     className="inline-flex items-center gap-1 text-slate-900 transition hover:text-aurora dark:text-white dark:hover:text-neon"
                   >
-                    Ver projeto
+                    {language === 'en' ? 'View project' : 'Ver projeto'}
                     <FiArrowUpRight />
                   </a>
                 )}

--- a/src/components/ResponsiveMenu.tsx
+++ b/src/components/ResponsiveMenu.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { FiGithub, FiLinkedin, FiMenu, FiX } from 'react-icons/fi';
 import { ThemeToggle } from './ThemeToggle';
+import { LanguageToggle } from './LanguageToggle';
+import { useLanguage } from '../hooks/useLanguage';
 
 type ResponsiveMenuProps = {
   items: Array<{ label: string; href: string }>;
@@ -8,6 +10,9 @@ type ResponsiveMenuProps = {
 
 export function ResponsiveMenu({ items }: ResponsiveMenuProps) {
   const [isOpened, setIsOpened] = useState(false);
+  const { language } = useLanguage();
+  const menuLabel = language === 'en' ? 'Menu' : 'Menu';
+  const openLabel = language === 'en' ? 'Open navigation menu' : 'Abrir menu de navegação';
 
   useEffect(() => {
     const toggleBodyOverflow = () => {
@@ -27,7 +32,7 @@ export function ResponsiveMenu({ items }: ResponsiveMenuProps) {
       <button
         onClick={() => setIsOpened(prev => !prev)}
         className="relative z-50 rounded-full border border-slate-300 dark:border-white/10 bg-slate-100 dark:bg-white/5 p-2 text-slate-900 dark:text-white transition hover:border-aurora dark:hover:border-neon/60 hover:text-aurora dark:hover:text-neon"
-        aria-label="Abrir menu de navegação"
+        aria-label={openLabel}
       >
         {isOpened ? <FiX size={22} /> : <FiMenu size={22} />}
       </button>
@@ -35,8 +40,9 @@ export function ResponsiveMenu({ items }: ResponsiveMenuProps) {
       {isOpened && (
         <nav className="fixed inset-0 z-40 flex flex-col bg-white dark:bg-charcoal/95 backdrop-blur-xl">
           <div className="flex items-center justify-between px-6 py-5">
-            <span className="text-lg font-semibold text-slate-900 dark:text-white">Menu</span>
-            <div className="flex items-center mr-14">
+            <span className="text-lg font-semibold text-slate-900 dark:text-white">{menuLabel}</span>
+            <div className="flex items-center gap-3 mr-14">
+              <LanguageToggle />
               <ThemeToggle />
             </div>
           </div>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,40 +1,64 @@
 import { Reveal } from './Reveal';
+import { useLanguage } from '../hooks/useLanguage';
 
-const SKILL_GROUPS = [
-  {
-    title: 'Frontend',
-    items: ['React 19', 'Next.js (SSR/SSG)', 'TypeScript', 'TanStack Router/Query', 'Tailwind CSS', 'Design Systems', 'Acessibilidade', 'SEO/Performance']
+const CONTENT = {
+  en: {
+    title: 'Stack & Skills',
+    subtitle: 'Core technologies used across backend, frontend, and infrastructure.',
+    groups: [
+      {
+        title: 'Frontend',
+        items: ['React.js', 'Next.js', 'TypeScript', 'JavaScript', 'HTML', 'CSS', 'SASS', 'Tailwind CSS']
+      },
+      {
+        title: 'Backend & Data',
+        items: ['Java (Spring Boot)', 'Node.js', 'GraphQL', 'REST APIs', 'PostgreSQL', 'MongoDB']
+      },
+      {
+        title: 'Infrastructure & Tooling',
+        items: ['Docker', 'Git & GitHub', 'CI/CD', 'Google Cloud Platform (GCP)']
+      }
+    ]
   },
-  {
-    title: 'Backend & Dados',
-    items: ['Node.js', 'Java · Spring Boot', 'Python · FastAPI', 'Microsserviços', 'APIs REST e GraphQL', 'Autenticação JWT', 'PostgreSQL', 'MySQL']
-  },
-  {
-    title: 'DevOps & Arquitetura',
-    items: ['Docker', 'Nginx', 'CI/CD', 'VPS Linux', 'Observabilidade', 'Infraestrutura como código', 'LGPD', 'ISO 38500']
-  },
-  {
-    title: 'Processos & Qualidade',
-    items: ['Documentação técnica', 'Padronização de código', 'Metodologias ágeis', 'Testing (unitário e integração)', 'Code Review', 'Mentoria técnica']
+  pt: {
+    title: 'Stack & Habilidades',
+    subtitle: 'Tecnologias centrais usadas em backend, frontend e infraestrutura.',
+    groups: [
+      {
+        title: 'Frontend',
+        items: ['React.js', 'Next.js', 'TypeScript', 'JavaScript', 'HTML', 'CSS', 'SASS', 'Tailwind CSS']
+      },
+      {
+        title: 'Backend & Dados',
+        items: ['Java (Spring Boot)', 'Node.js', 'GraphQL', 'APIs REST', 'PostgreSQL', 'MongoDB']
+      },
+      {
+        title: 'Infraestrutura & Ferramentas',
+        items: ['Docker', 'Git & GitHub', 'CI/CD', 'Google Cloud Platform (GCP)']
+      }
+    ]
   }
-];
+};
 
 export function Skills() {
+  const { language } = useLanguage();
+  const content = CONTENT[language];
+
   return (
     <section id="habilidades" className="relative mx-auto max-w-[1440px] px-6 py-24">
       <div className="pointer-events-none absolute inset-x-6 top-16 -z-10 h-[420px] rounded-[36px] bg-light-layer opacity-90 blur-2xl dark:hidden" />
       <div className="pointer-events-none absolute inset-x-12 top-24 -z-10 hidden h-[420px] rounded-[32px] bg-gradient-to-r from-charcoal/85 via-midnight/80 to-charcoal/85 blur-3xl dark:block" />
       <Reveal>
         <div className="flex flex-col gap-4">
-          <h2 className="section-title text-slate-900 dark:text-white">Stack & Habilidades</h2>
+          <h2 className="section-title text-slate-900 dark:text-white">{content.title}</h2>
           <p className="section-subtitle">
-            Tecnologia para entregar soluções robustas, performáticas e fáceis de evoluir.
+            {content.subtitle}
           </p>
         </div>
       </Reveal>
 
       <div className="mt-12 grid gap-6 md:grid-cols-2">
-        {SKILL_GROUPS.map((group, index) => (
+        {content.groups.map((group, index) => (
           <Reveal key={group.title} delay={index * 120}>
             <div className="glass-panel relative h-full overflow-hidden rounded-2xl border border-white/70 bg-white/85 p-6 shadow-aurora backdrop-blur-sm dark:border-white/10 dark:bg-white/5 dark:shadow-card">
               <span className="pointer-events-none absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-aurora via-emerald-400 to-sunrise dark:from-neon dark:via-emerald-400 dark:to-aurora" />

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,15 +1,22 @@
 import { FiMoon, FiSun } from 'react-icons/fi';
 import { useTheme } from '../hooks/useTheme';
+import { useLanguage } from '../hooks/useLanguage';
 
 export function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
+  const { language } = useLanguage();
+  const isDark = theme === 'dark';
+  const label =
+    language === 'en'
+      ? `Switch to ${isDark ? 'light' : 'dark'} mode`
+      : `Alternar para tema ${isDark ? 'claro' : 'escuro'}`;
 
   return (
     <button
       onClick={toggleTheme}
       className="rounded-full border border-white/10 bg-white/5 text-slate hover:border-gray-300 hover:shadow-glow transition"
-      aria-label="Alternar tema"
-      title={`Alternar para tema ${theme === 'dark' ? 'claro' : 'escuro'}`}
+      aria-label={label}
+      title={label}
     >
       {theme === 'dark' ? (
         <FiSun className='w-9 h-9 p-1'/>

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+import { LanguageContext, type Language } from './languageContext';
+
+export function LanguageProvider({ children }: { children: React.ReactNode }) {
+  const [language, setLanguage] = useState<Language>('en');
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const savedLanguage = localStorage.getItem('language') as Language | null;
+    const browserLanguage = navigator.language.toLowerCase().startsWith('pt') ? 'pt' : 'en';
+    const initialLanguage = savedLanguage ?? browserLanguage;
+    setLanguage(initialLanguage);
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    localStorage.setItem('language', language);
+  }, [language, mounted]);
+
+  const toggleLanguage = () => {
+    setLanguage(prev => (prev === 'en' ? 'pt' : 'en'));
+  };
+
+  return (
+    <LanguageContext.Provider value={{ language, toggleLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}

--- a/src/contexts/languageContext.ts
+++ b/src/contexts/languageContext.ts
@@ -1,0 +1,10 @@
+import { createContext } from 'react';
+
+export type Language = 'en' | 'pt';
+
+export interface LanguageContextType {
+  language: Language;
+  toggleLanguage: () => void;
+}
+
+export const LanguageContext = createContext<LanguageContextType | undefined>(undefined);

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { LanguageContext } from '../contexts/languageContext';
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (context === undefined) {
+    throw new Error('useLanguage must be used within LanguageProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
### Motivation
- Align site copy with the verified profile to emphasize backend ownership, system architecture responsibilities, and production experience without inventing or inflating details.
- Remove unverified technologies, project claims and entries from the public portfolio content to ensure accuracy.
- Make UI labels, resume download filename, and small controls language-aware and persistent across sessions.

### Description
- Updated English and Portuguese content in `src/components/Main.tsx`, `src/components/About.tsx`, `src/components/Experience.tsx`, `src/components/Projects.tsx`, and `src/components/Skills.tsx` to match the provided, verified professional details and tech stack.
- Added a lightweight language context and provider with `src/contexts/languageContext.ts`, `src/contexts/LanguageContext.tsx`, and a hook `src/hooks/useLanguage.ts`, plus a `LanguageToggle` component at `src/components/LanguageToggle.tsx` and wired language state into `Header`, `ResponsiveMenu`, `BackToTopBtn`, `ThemeToggle`, `Contact`, and `App` for language-aware labels and behavior.
- Adjusted footer role text and resume download filename/behavior to reflect the verified profile and selected language, and removed references to unverified items (AI microservices, LangChain/FastAPI mentions, freelance project entries and other unconfirmed technologies) from public highlights and stacks.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported the server as ready.
- Ran a Playwright script to open `http://127.0.0.1:4173` and capture a full-page screenshot, which produced `artifacts/portfolio-english-toggle-updated.png` successfully.
- No unit tests were added to this change set (content and UI wiring only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c2f00f4008331af62e84c25bc697d)