### PR TITLE
Default initial language to English

### DIFF
--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -7,8 +7,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const savedLanguage = localStorage.getItem('language') as Language | null;
-    const browserLanguage = navigator.language.toLowerCase().startsWith('pt') ? 'pt' : 'en';
-    const initialLanguage = savedLanguage ?? browserLanguage;
+    const initialLanguage = savedLanguage ?? 'en';
     setLanguage(initialLanguage);
     setMounted(true);
   }, []);


### PR DESCRIPTION
### Motivation
- Ensure English is the default language when the user has not previously selected a language, avoiding automatic Portuguese selection based on the browser.

### Description
- Update `src/contexts/LanguageContext.tsx` to set `initialLanguage = savedLanguage ?? 'en'` instead of deriving it from `navigator.language`, so the app defaults to English when no `localStorage` value exists.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c392be1088331b6898688601b76f0)